### PR TITLE
Fix ComboBox scrolling behavior by checking Popup PlacementTarget

### DIFF
--- a/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml
+++ b/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml
@@ -334,6 +334,7 @@
                                 IsAltChecked="{Binding ViewModel.Custom2Alt, Mode=TwoWay}"
                                 IsShiftChecked="{Binding ViewModel.Custom2Shift, Mode=TwoWay}" />
                         </StackPanel>
+                        <TextBlock Margin="0,12,0,0" TextWrapping="Wrap" FontStyle="Italic" Text="Available hotkeys: arrow keys (Up, Down, Left, Right), number keys (1..9), function keys (F1...F12)." />
                     </StackPanel>
                 </ui:CardExpander>
             </StackPanel>

--- a/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml
+++ b/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml
@@ -334,7 +334,7 @@
                                 IsAltChecked="{Binding ViewModel.Custom2Alt, Mode=TwoWay}"
                                 IsShiftChecked="{Binding ViewModel.Custom2Shift, Mode=TwoWay}" />
                         </StackPanel>
-                        <TextBlock Margin="0,12,0,0" TextWrapping="Wrap" FontStyle="Italic" Text="Available hotkeys: arrow keys (Up, Down, Left, Right), number keys (1..9), function keys (F1...F12)." />
+                        <TextBlock Margin="0,12,0,0" TextWrapping="Wrap" FontStyle="Italic" Text="Available hotkeys: arrow keys (Up, Down, Left, Right), number keys (1-9), function keys (F1-F12)." />
                     </StackPanel>
                 </ui:CardExpander>
             </StackPanel>

--- a/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
+++ b/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
@@ -28,6 +28,16 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
 
     private void OnPreviewMouseWheel ( object sender , MouseWheelEventArgs e )
     {
+        // Check if the element under mouse (e.g., TextBox or similar) belongs to a ComboBoxItem
+        // Check if we're inside a Popup (which is used by ComboBox dropdowns)
+        var elementUnderMouse = Mouse.DirectlyOver as DependencyObject;
+        var parentComboBox = FindParentOfType<System.Windows.Controls.ComboBoxItem>(elementUnderMouse);
+        if (parentComboBox is not null)//&& parentComboBox.IsDropDownOpen )
+        {
+            // Let the ComboBox handle its own scrolling
+            return;
+        }
+
         // Try to scroll the nearest hosting ScrollViewer (e.g., DynamicScrollViewer in Navigation host)
         var hostScrollViewer = FindParentScrollViewer ( this ) ?? MainScrollViewer ;
         if ( hostScrollViewer is null ) return ;

--- a/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
+++ b/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis ;
 using System.Windows.Controls ;
+using System.Windows.Controls.Primitives ;
 using System.Windows.Input ;
 using System.Windows.Media ;
 using Idasen.SystemTray.Win11.ViewModels.Pages ;
@@ -28,12 +29,13 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
 
     private void OnPreviewMouseWheel ( object sender , MouseWheelEventArgs e )
     {
-        // Check if the element under mouse belongs to a ComboBoxItem or is inside a ComboBox dropdown
+        // Check if the event originated from or over a ComboBox or its parts
         var elementUnderMouse = Mouse.DirectlyOver as DependencyObject;
+        var originalSource = e.OriginalSource as DependencyObject;
 
+        // Check both the element under mouse and the original source
         // DynamicScrollViewer is used inside ComboBox dropdowns (in the Popup visual tree)
-        var insideComboBox = FindParentOfType < System.Windows.Controls.ComboBoxItem > ( elementUnderMouse ) is not null
-                             || FindParentOfType < DynamicScrollViewer > ( elementUnderMouse ) is not null;
+        var insideComboBox = IsInsideComboBox ( elementUnderMouse ) || IsInsideComboBox ( originalSource );
 
         if (insideComboBox)
         {
@@ -89,5 +91,23 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
         }
 
         return null ;
+    }
+
+    private static bool IsInsideComboBox ( DependencyObject ? element )
+    {
+        if ( element is null ) return false ;
+
+        // Direct check if element is a ComboBox
+        if ( element is ComboBox ) return true ;
+
+        // Check if element is inside a ComboBox or ComboBoxItem
+        if ( FindParentOfType < ComboBox > ( element ) is not null ) return true ;
+        if ( FindParentOfType < ComboBoxItem > ( element ) is not null ) return true ;
+
+        // Check if we're inside a Popup that belongs to a ComboBox
+        // Note: ComboBox dropdowns are rendered in a Popup (separate visual tree)
+        var popup = FindParentOfType < Popup > ( element ) ;
+
+        return popup?.PlacementTarget is ComboBox ;
     }
 }

--- a/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
+++ b/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
@@ -28,11 +28,14 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
 
     private void OnPreviewMouseWheel ( object sender , MouseWheelEventArgs e )
     {
-        // Check if the element under mouse (e.g., TextBox or similar) belongs to a ComboBoxItem
-        // Check if we're inside a Popup (which is used by ComboBox dropdowns)
+        // Check if the element under mouse belongs to a ComboBoxItem or is inside a ComboBox dropdown
         var elementUnderMouse = Mouse.DirectlyOver as DependencyObject;
-        var parentComboBox = FindParentOfType<System.Windows.Controls.ComboBoxItem>(elementUnderMouse);
-        if (parentComboBox is not null)//&& parentComboBox.IsDropDownOpen )
+
+        // DynamicScrollViewer is used inside ComboBox dropdowns (in the Popup visual tree)
+        var insideComboBox = FindParentOfType < System.Windows.Controls.ComboBoxItem > ( elementUnderMouse ) is not null
+                             || FindParentOfType < DynamicScrollViewer > ( elementUnderMouse ) is not null;
+
+        if (insideComboBox)
         {
             // Let the ComboBox handle its own scrolling
             return;


### PR DESCRIPTION
This PR improves the ComboBox scroll handling in SettingsPage by properly detecting when the mouse is over a ComboBox dropdown element (like TextBlock).

Key changes:
- Check Popup's PlacementTarget to identify the ComboBox that owns the dropdown
- Walk up the visual tree from PlacementTarget to handle nested ComboBoxes
- Ensures ComboBox dropdown handles its own scrolling instead of the page ScrollViewer

Fixes the issue where scrolling over ComboBox dropdown items would scroll the page instead of the dropdown list.