### PR TITLE
Fix mouse wheel scrolling detection for ComboBox dropdowns

### DIFF
--- a/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
+++ b/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
@@ -34,8 +34,8 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
     private void OnPreviewMouseWheel ( object sender , MouseWheelEventArgs e )
     {
         // Check if the event originated from or over a ComboBox or its parts
-        var elementUnderMouse = Mouse.DirectlyOver as DependencyObject;
-        var originalSource = e.OriginalSource as DependencyObject;
+        var elementUnderMouse = Mouse.DirectlyOver as DependencyObject ;
+        var originalSource = e.OriginalSource as DependencyObject ;
 
         // Log element types for debugging
         _logger.Debug ( "Mouse wheel: ElementUnderMouse={ElementType}, OriginalSource={SourceType}" ,
@@ -43,8 +43,8 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
                         originalSource?.GetType().Name ?? "null" ) ;
 
         // Check for popup
-        var mousePopup = FindAssociatedPopup ( elementUnderMouse );
-        var sourcePopup = FindAssociatedPopup ( originalSource );
+        var mousePopup = FindAssociatedPopup ( elementUnderMouse ) ;
+        var sourcePopup = FindAssociatedPopup ( originalSource ) ;
 
         if ( mousePopup is not null )
         {
@@ -59,15 +59,15 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
         }
 
         // Check both the element under mouse and the original source
-        var insideComboBox = IsInsideComboBox ( elementUnderMouse ) || IsInsideComboBox ( originalSource );
+        var insideComboBox = IsInsideComboBox ( elementUnderMouse ) || IsInsideComboBox ( originalSource ) ;
 
         _logger.Debug ( "InsideComboBox={Inside}" , insideComboBox ) ;
 
-        if (insideComboBox)
+        if ( insideComboBox )
         {
             _logger.Debug ( "Returning early - inside ComboBox" ) ;
             // Let the ComboBox handle its own scrolling
-            return;
+            return ;
         }
 
         // Try to scroll the nearest hosting ScrollViewer (e.g., DynamicScrollViewer in Navigation host)
@@ -156,8 +156,8 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
         // Try LogicalTreeHelper
         var logicalParent = LogicalTreeHelper.GetParent ( visualRoot! ) ;
 
-        if ( logicalParent is Popup popupParent2)
-            return popupParent2;
+        if ( logicalParent is Popup popupParent2 )
+            return popupParent2 ;
 
         return null ;
     }

--- a/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
+++ b/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Input ;
 using System.Windows.Media ;
 using Idasen.SystemTray.Win11.ViewModels.Pages ;
 using Serilog ;
+using Serilog.Events ;
 using Wpf.Ui.Abstractions.Controls ;
 using Wpf.Ui.Controls ;
 
@@ -37,35 +38,45 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
         var elementUnderMouse = Mouse.DirectlyOver as DependencyObject ;
         var originalSource = e.OriginalSource as DependencyObject ;
 
-        // Log element types for debugging
-        _logger.Debug ( "Mouse wheel: ElementUnderMouse={ElementType}, OriginalSource={SourceType}" ,
-                        elementUnderMouse?.GetType().Name ?? "null" ,
-                        originalSource?.GetType().Name ?? "null" ) ;
-
-        // Check for popup
-        var mousePopup = FindAssociatedPopup ( elementUnderMouse ) ;
-        var sourcePopup = FindAssociatedPopup ( originalSource ) ;
-
-        if ( mousePopup is not null )
+        // Guard debug logging and associated popup lookups behind level check
+        if ( _logger.IsEnabled ( LogEventLevel.Debug ) )
         {
-            _logger.Debug ( "Mouse popup found: PlacementTarget={TargetType}" ,
-                            mousePopup.PlacementTarget?.GetType().Name ?? "null" ) ;
-        }
+            // Log element types for debugging
+            _logger.Debug ( "Mouse wheel: ElementUnderMouse={ElementType}, OriginalSource={SourceType}" ,
+                            elementUnderMouse?.GetType().Name ?? "null" ,
+                            originalSource?.GetType().Name ?? "null" ) ;
 
-        if ( sourcePopup is not null )
-        {
-            _logger.Debug ( "Source popup found: PlacementTarget={TargetType}" ,
-                            sourcePopup.PlacementTarget?.GetType().Name ?? "null" ) ;
+            // Check for popup (only for logging purposes)
+            var mousePopup = FindAssociatedPopup ( elementUnderMouse ) ;
+            var sourcePopup = FindAssociatedPopup ( originalSource ) ;
+
+            if ( mousePopup is not null )
+            {
+                _logger.Debug ( "Mouse popup found: PlacementTarget={TargetType}" ,
+                                mousePopup.PlacementTarget?.GetType().Name ?? "null" ) ;
+            }
+
+            if ( sourcePopup is not null )
+            {
+                _logger.Debug ( "Source popup found: PlacementTarget={TargetType}" ,
+                                sourcePopup.PlacementTarget?.GetType().Name ?? "null" ) ;
+            }
         }
 
         // Check both the element under mouse and the original source
         var insideComboBox = IsInsideComboBox ( elementUnderMouse ) || IsInsideComboBox ( originalSource ) ;
 
-        _logger.Debug ( "InsideComboBox={Inside}" , insideComboBox ) ;
+        if ( _logger.IsEnabled ( LogEventLevel.Debug ) )
+        {
+            _logger.Debug ( "InsideComboBox={Inside}" , insideComboBox ) ;
+        }
 
         if ( insideComboBox )
         {
-            _logger.Debug ( "Returning early - inside ComboBox" ) ;
+            if ( _logger.IsEnabled ( LogEventLevel.Debug ) )
+            {
+                _logger.Debug ( "Returning early - inside ComboBox" ) ;
+            }
             // Let the ComboBox handle its own scrolling
             return ;
         }

--- a/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
+++ b/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
@@ -150,22 +150,21 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
             maxDepth ++;
         }
 
-        switch ( visualRoot )
+        // Check if the visual root has a Popup as its logical parent
+        if ( visualRoot != null )
         {
-            // Check if the visual root has a Popup as its logical parent
-            case null :
-                return null ;
-            // Try FrameworkElement.Parent first (faster)
-            case FrameworkElement { Parent: Popup p1 } :
-                return p1 ;
+            if ( visualRoot is FrameworkElement { Parent: Popup p1 } ) return p1 ;
+
+            // Try LogicalTreeHelper
+            var logicalParent = LogicalTreeHelper.GetParent ( visualRoot ) ;
+
+            if ( logicalParent is Popup p2 )
+                return p2 ;
+
+            return null ;
         }
 
-        // Try LogicalTreeHelper
-        var logicalParent = LogicalTreeHelper.GetParent ( visualRoot ) ;
-
-        if ( logicalParent is Popup p2 ) 
-            return p2 ;
-
+        // Try FrameworkElement.Parent first (faster)
         return null ;
     }
 

--- a/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
+++ b/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
@@ -131,13 +131,13 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
 
         // For elements inside PopupRoot (separate visual tree), we need to walk up to the root
         // then check the logical parent which should be the Popup
-        var current = element ;
+        var                current    = element ;
         DependencyObject ? visualRoot = null ;
 
-        var maxDepth = 0; // Prevent infinite loops in case of malformed visual trees
+        var maxDepth = 0 ; // Prevent infinite loops in case of malformed visual trees
 
         // Walk up the visual tree to find the root
-        while (maxDepth < 100)
+        while ( maxDepth < 100 )
         {
             visualRoot = current ;
             var parent = VisualTreeHelper.GetParent ( current ) ;
@@ -146,25 +146,22 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
                 // We've reached the visual root
                 break ;
             }
+
             current = parent ;
-            maxDepth ++;
+            maxDepth ++ ;
         }
 
         // Check if the visual root has a Popup as its logical parent
-        if ( visualRoot != null )
-        {
-            if ( visualRoot is FrameworkElement { Parent: Popup p1 } ) return p1 ;
+        if ( visualRoot is FrameworkElement { Parent: Popup popupParent1 } ) return popupParent1 ;
 
-            // Try LogicalTreeHelper
-            var logicalParent = LogicalTreeHelper.GetParent ( visualRoot ) ;
+        if ( visualRoot == null ) return null ;
 
-            if ( logicalParent is Popup p2 )
-                return p2 ;
+        // Try LogicalTreeHelper
+        var logicalParent = LogicalTreeHelper.GetParent ( visualRoot ) ;
 
-            return null ;
-        }
+        if ( logicalParent is Popup popupParent2)
+            return popupParent2;
 
-        // Try FrameworkElement.Parent first (faster)
         return null ;
     }
 

--- a/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
+++ b/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis ;
-using System.Windows ;
 using System.Windows.Controls ;
 using System.Windows.Controls.Primitives ;
 using System.Windows.Input ;
@@ -154,10 +153,8 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
         // Check if the visual root has a Popup as its logical parent
         if ( visualRoot is FrameworkElement { Parent: Popup popupParent1 } ) return popupParent1 ;
 
-        if ( visualRoot == null ) return null ;
-
         // Try LogicalTreeHelper
-        var logicalParent = LogicalTreeHelper.GetParent ( visualRoot ) ;
+        var logicalParent = LogicalTreeHelper.GetParent ( visualRoot! ) ;
 
         if ( logicalParent is Popup popupParent2)
             return popupParent2;

--- a/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
+++ b/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
@@ -86,9 +86,8 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
         if ( hostScrollViewer is null ) return ;
 
         // Detect whether the wheel event originated over an expander control
-        var source = e.OriginalSource as DependencyObject ;
-        var overExpander = FindParentOfType < CardExpander > ( source ) is not null ||
-                           FindParentOfType < Expander > ( source ) is not null ;
+        var overExpander = FindParentOfType < CardExpander > ( originalSource ) is not null ||
+                           FindParentOfType < Expander > ( originalSource ) is not null ;
 
         // Increase scroll speed when over expander controls
         var steps = overExpander

--- a/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
+++ b/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
@@ -134,8 +134,10 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
         var current = element ;
         DependencyObject ? visualRoot = null ;
 
+        var maxDepth = 0; // Prevent infinite loops in case of malformed visual trees
+
         // Walk up the visual tree to find the root
-        while ( current != null )
+        while (maxDepth < 100)
         {
             visualRoot = current ;
             var parent = VisualTreeHelper.GetParent ( current ) ;
@@ -145,20 +147,24 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
                 break ;
             }
             current = parent ;
+            maxDepth ++;
         }
 
-        // Check if the visual root has a Popup as its logical parent
-        if ( visualRoot is not null )
+        switch ( visualRoot )
         {
+            // Check if the visual root has a Popup as its logical parent
+            case null :
+                return null ;
             // Try FrameworkElement.Parent first (faster)
-            if ( visualRoot is FrameworkElement fe && fe.Parent is Popup p1 )
+            case FrameworkElement { Parent: Popup p1 } :
                 return p1 ;
-
-            // Try LogicalTreeHelper
-            var logicalParent = LogicalTreeHelper.GetParent ( visualRoot ) ;
-            if ( logicalParent is Popup p2 ) 
-                return p2 ;
         }
+
+        // Try LogicalTreeHelper
+        var logicalParent = LogicalTreeHelper.GetParent ( visualRoot ) ;
+
+        if ( logicalParent is Popup p2 ) 
+            return p2 ;
 
         return null ;
     }

--- a/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
+++ b/src/Idasen.SystemTray.Win11/Views/Pages/SettingsPage.xaml.cs
@@ -1,9 +1,11 @@
 ﻿using System.Diagnostics.CodeAnalysis ;
+using System.Windows ;
 using System.Windows.Controls ;
 using System.Windows.Controls.Primitives ;
 using System.Windows.Input ;
 using System.Windows.Media ;
 using Idasen.SystemTray.Win11.ViewModels.Pages ;
+using Serilog ;
 using Wpf.Ui.Abstractions.Controls ;
 using Wpf.Ui.Controls ;
 
@@ -12,8 +14,11 @@ namespace Idasen.SystemTray.Win11.Views.Pages ;
 [ ExcludeFromCodeCoverage ]
 public partial class SettingsPage : INavigableView < SettingsViewModel >
 {
-    public SettingsPage ( SettingsViewModel viewModel )
+    private readonly ILogger _logger ;
+
+    public SettingsPage ( SettingsViewModel viewModel , ILogger logger )
     {
+        _logger     = logger ;
         ViewModel   = viewModel ;
         DataContext = this ;
 
@@ -33,12 +38,35 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
         var elementUnderMouse = Mouse.DirectlyOver as DependencyObject;
         var originalSource = e.OriginalSource as DependencyObject;
 
+        // Log element types for debugging
+        _logger.Debug ( "Mouse wheel: ElementUnderMouse={ElementType}, OriginalSource={SourceType}" ,
+                        elementUnderMouse?.GetType().Name ?? "null" ,
+                        originalSource?.GetType().Name ?? "null" ) ;
+
+        // Check for popup
+        var mousePopup = FindAssociatedPopup ( elementUnderMouse );
+        var sourcePopup = FindAssociatedPopup ( originalSource );
+
+        if ( mousePopup is not null )
+        {
+            _logger.Debug ( "Mouse popup found: PlacementTarget={TargetType}" ,
+                            mousePopup.PlacementTarget?.GetType().Name ?? "null" ) ;
+        }
+
+        if ( sourcePopup is not null )
+        {
+            _logger.Debug ( "Source popup found: PlacementTarget={TargetType}" ,
+                            sourcePopup.PlacementTarget?.GetType().Name ?? "null" ) ;
+        }
+
         // Check both the element under mouse and the original source
-        // DynamicScrollViewer is used inside ComboBox dropdowns (in the Popup visual tree)
         var insideComboBox = IsInsideComboBox ( elementUnderMouse ) || IsInsideComboBox ( originalSource );
+
+        _logger.Debug ( "InsideComboBox={Inside}" , insideComboBox ) ;
 
         if (insideComboBox)
         {
+            _logger.Debug ( "Returning early - inside ComboBox" ) ;
             // Let the ComboBox handle its own scrolling
             return;
         }
@@ -93,6 +121,48 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
         return null ;
     }
 
+    private static Popup ? FindAssociatedPopup ( DependencyObject ? element )
+    {
+        if ( element is null ) return null ;
+
+        // Try to find Popup in visual tree first
+        var popup = FindParentOfType < Popup > ( element ) ;
+        if ( popup is not null ) return popup ;
+
+        // For elements inside PopupRoot (separate visual tree), we need to walk up to the root
+        // then check the logical parent which should be the Popup
+        var current = element ;
+        DependencyObject ? visualRoot = null ;
+
+        // Walk up the visual tree to find the root
+        while ( current != null )
+        {
+            visualRoot = current ;
+            var parent = VisualTreeHelper.GetParent ( current ) ;
+            if ( parent is null )
+            {
+                // We've reached the visual root
+                break ;
+            }
+            current = parent ;
+        }
+
+        // Check if the visual root has a Popup as its logical parent
+        if ( visualRoot is not null )
+        {
+            // Try FrameworkElement.Parent first (faster)
+            if ( visualRoot is FrameworkElement fe && fe.Parent is Popup p1 )
+                return p1 ;
+
+            // Try LogicalTreeHelper
+            var logicalParent = LogicalTreeHelper.GetParent ( visualRoot ) ;
+            if ( logicalParent is Popup p2 ) 
+                return p2 ;
+        }
+
+        return null ;
+    }
+
     private static bool IsInsideComboBox ( DependencyObject ? element )
     {
         if ( element is null ) return false ;
@@ -100,14 +170,21 @@ public partial class SettingsPage : INavigableView < SettingsViewModel >
         // Direct check if element is a ComboBox
         if ( element is ComboBox ) return true ;
 
-        // Check if element is inside a ComboBox or ComboBoxItem
+        // Check if element is inside a ComboBox or ComboBoxItem in the main visual tree
         if ( FindParentOfType < ComboBox > ( element ) is not null ) return true ;
         if ( FindParentOfType < ComboBoxItem > ( element ) is not null ) return true ;
 
         // Check if we're inside a Popup that belongs to a ComboBox
-        // Note: ComboBox dropdowns are rendered in a Popup (separate visual tree)
-        var popup = FindParentOfType < Popup > ( element ) ;
+        // ComboBox dropdowns are rendered in a Popup (separate visual tree)
+        var popup = FindAssociatedPopup ( element ) ;
+        if ( popup is not null )
+        {
+            // The PlacementTarget might be a Border or other element inside the ComboBox
+            // So we need to check if the PlacementTarget itself is inside a ComboBox
+            if ( popup.PlacementTarget is ComboBox ) return true ;
+            if ( FindParentOfType < ComboBox > ( popup.PlacementTarget ) is not null ) return true ;
+        }
 
-        return popup?.PlacementTarget is ComboBox ;
+        return false ;
     }
 }


### PR DESCRIPTION
## Problem
When using the mouse wheel over a ComboBox dropdown's scrollbar, the main page would scroll instead of the ComboBox items. This happened because the event detection didn't properly identify elements inside the ComboBox dropdown's Popup.

## Solution
- Added logger injection to SettingsPage for debugging
- Implemented FindAssociatedPopup method to detect Popup elements across visual tree boundaries (ComboBox dropdowns render in a separate PopupRoot visual tree)
- Fixed ComboBox dropdown detection by checking if the Popup's PlacementTarget is inside a ComboBox (not just if it IS a ComboBox, since WPF places the dropdown relative to a Border inside the ComboBox)
- Added debug logging for mouse wheel events and ComboBox detection for future troubleshooting

## Testing
✅ Main page scrolls correctly with mouse wheel
✅ ComboBox dropdown items scroll correctly with mouse wheel
✅ ComboBox dropdown scrollbar works correctly without scrolling the main page

Fixes #116